### PR TITLE
11528 breakdown app

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -44,6 +44,7 @@ exclude =
     python/tank/authentication/ui/login_dialog.py,
     python/tank/authentication/ui/resources_rc.py,
     python/tank/authentication/sso_saml2/*,
+    python/tk_multi_breakdown2/ui,
     tests/python
 
 # toolkit exceptions

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,76 @@
+# Copyright 2023 GPL Solutions, LLC.  All rights reserved.
+#
+# Use of this software is subject to the terms of the GPL Solutions license
+# agreement provided at the time of installation or download, or which otherwise
+# accompanies this software in either electronic or hard copy form.
+#
+
+name: Run tests
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - "*.md"
+      - "*.in"
+      - "*.txt"
+
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - "*.md"
+      - "*.in"
+      - "*.txt"
+
+jobs:
+  test-tk-multi-breakdown2:
+
+    name: "tk-multi-breakdown2"
+    strategy:
+      matrix:
+        python-version: ['3.11']
+        os: [ubuntu-latest, macos-latest] # windows-latest when wheel is in place
+
+    runs-on: ${{ matrix.os }}
+
+    env:
+      OS: ${{ matrix.os }}
+      PYTHON: ${{ matrix.python-version }}
+      GH_COV_PY: 3.11
+      GH_COV_OS: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install six
+          pip install git+https://github.com/shotgunsoftware/python-api.git
+
+      - name: Lint with flake8
+        run: |
+          flake8 --show-source --statistics --config .flake8
+
+#      - name: Test with pytest
+#        run: |
+#          pip install pytest
+#          pip install pytest-cov
+#          pytest -s --cov=./ --cov-report=xml
+#
+#      - name: Upload coverage to Codecov
+#        if: matrix.python-version == env.GH_COV_PY && matrix.os == env.GH_COV_OS
+#        uses: codecov/codecov-action@v3
+#        with:
+#          token: ${{ secrets.CODECOV_TOKEN }}
+#          flags: unittests
+#          name: sg-jira-codecov
+#          fail_ci_if_error: true
+#          env_vars: OS,PYTHON
+
+#        shell: bash

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,8 +50,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install six
-          pip install git+https://github.com/shotgunsoftware/python-api.git
+          pip install flake8
 
       - name: Lint with flake8
         run: |

--- a/app.py
+++ b/app.py
@@ -114,7 +114,7 @@ class SceneBreakdown2(sgtk.platform.Application):
                 log_once=False,
                 bundle=self,
             )
-        except:
+        except Exception:
             # Ignore all errors, e.g. using a core that does not support metrics.
             pass
 

--- a/hooks/get_published_files.py
+++ b/hooks/get_published_files.py
@@ -8,7 +8,6 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Autodesk, Inc.
 
-import copy
 import sgtk
 
 HookBaseClass = sgtk.get_hook_baseclass()

--- a/hooks/get_published_files.py
+++ b/hooks/get_published_files.py
@@ -17,11 +17,11 @@ HookBaseClass = sgtk.get_hook_baseclass()
 class GetPublishedFiles(HookBaseClass):
     """"""
 
-    def get_published_files_for_scene_objects(self, scene_objects, fields):
+    def get_published_files_for_items_data(self, items_data, fields):
         """
-        Return the Published Files for the given scene objects.
+        Return the Published Files for the given items data.
 
-        Scene objects are dictionaries with the following expected keys:
+        Items data are dictionaries with the following expected keys:
         - "node_name": The name of the 'node' that is to be operated on. Most DCCs have
           a concept of a node, path or some other way to address a particular
           object in the scene.
@@ -31,29 +31,29 @@ class GetPublishedFiles(HookBaseClass):
         - "extra_data": Optional key to pass some extra data to the update method
           in case we'd like to access them when updating the nodes.
 
-        Scene objects dictionaries for which a Published File was found are updated
-        with a `sg_data` key with the found Published File dictionary, allowing
+        Items data dictionaries for which a Published File is found are updated
+        with a "sg_data" key with the found Published File dictionary, allowing
         custom implementations to have full control on how scene objects are mapped
         to Published Files.
 
-        This implementation is based on scene object paths matching Published File paths.
+        This implementation is based on items data paths matching Published File paths.
 
-        :param scene_object: A list of dictionaries as returned by the scene scanner.
+        :param items_data: A list of dictionaries as returned by the scene scanner.
         :param fields: A list of fields to query from SG.
-        :returns: A list of scene objects for which a Published File was found.
+        :returns: A list of items data for which a Published File was found.
         """
-        if not scene_objects:
+        if not items_data:
             return []
-        file_paths = [o["path"] for o in scene_objects]
+        file_paths = [o["path"] for o in items_data]
         publishes = sgtk.util.find_publish(
             self.sgtk, file_paths, fields=fields, only_current_project=False
         )
-        published_scene_objects = []
-        for scene_object in scene_objects:
-            if scene_object["path"] in publishes:
-                scene_object["sg_data"] = publishes[scene_object["path"]]
-                published_scene_objects.append(scene_object)
-        return published_scene_objects
+        published_items_data = []
+        for item_data in items_data:
+            if item_data["path"] in publishes:
+                item_data["sg_data"] = publishes[item_data["path"]]
+                published_items_data.append(item_data)
+        return published_items_data
 
     def get_published_files_for_items(self, items, data_retriever=None):
         """

--- a/hooks/get_published_files.py
+++ b/hooks/get_published_files.py
@@ -16,6 +16,33 @@ HookBaseClass = sgtk.get_hook_baseclass()
 class GetPublishedFiles(HookBaseClass):
     """"""
 
+    def get_published_files_from_scene_objects(self, scene_objects, fields):
+        """
+        Return the Published Files for the given scene objects.
+
+        Scene objects are dictionaries with the following expected keys:
+        - "node_name": The name of the 'node' that is to be operated on. Most DCCs have
+          a concept of a node, path or some other way to address a particular
+          object in the scene.
+        - "node_type": The object type that this is. This is later passed to the
+          update method so that it knows how to handle the object.
+        - "path": Path on disk to the referenced object.
+        - "extra_data": Optional key to pass some extra data to the update method
+          in case we'd like to access them when updating the nodes.
+
+        :param scene_object: A list of dictionaries as returned by the scene scanner.
+        :param fields: A list of fields to query from SG.
+        :returns: A dictionary where keys are file paths and values SG Published Files
+                  dictionaries.
+        """
+        if not scene_objects:
+            return {}
+        file_paths = [o["path"] for o in scene_objects]
+        return sgtk.util.find_publish(
+            self.sgtk, file_paths, fields=fields, only_current_project=False
+        )
+
+
     def get_published_files_for_items(self, items, data_retriever=None):
         """
         Make an API request to get all published files for the given file items.

--- a/hooks/tk-alias_scene_operations.py
+++ b/hooks/tk-alias_scene_operations.py
@@ -122,7 +122,7 @@ class BreakdownSceneOperations(HookBaseClass):
         try:
             api_alias_version = alias_api.__alias_version__
             major_version = int(api_alias_version.split(".")[0])
-        except:
+        except Exception:
             major_version = -1
 
         if major_version >= 2023:

--- a/hooks/tk-mari_scene_operations.py
+++ b/hooks/tk-mari_scene_operations.py
@@ -8,8 +8,6 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Autodesk, Inc.
 
-import os
-
 import sgtk
 from sgtk import TankError
 

--- a/hooks/tk-maya_scene_operations.py
+++ b/hooks/tk-maya_scene_operations.py
@@ -104,7 +104,6 @@ class BreakdownSceneOperations(HookBaseClass):
             self.logger.debug(
                 "File Texture %s: Updating to version %s" % (node_name, path)
             )
-            file_name = cmds.getAttr("%s.fileTextureName" % node_name)
             cmds.setAttr("%s.fileTextureName" % node_name, path, type="string")
 
     def register_scene_change_callback(self, scene_change_callback):

--- a/hooks/tk-vred_scene_operations.py
+++ b/hooks/tk-vred_scene_operations.py
@@ -19,9 +19,9 @@ except ImportError:
     except ImportError:
         import __builtin__ as builtins
 
-builtins.vrNodeService = vrNodeService
-builtins.vrReferenceService = vrReferenceService
-builtins.vrFileIOService = vrFileIOService
+builtins.vrNodeService = vrNodeService  # noqa F821
+builtins.vrReferenceService = vrReferenceService  # noqa F821
+builtins.vrFileIOService = vrFileIOService  # noqa F821
 
 
 HookBaseClass = sgtk.get_hook_baseclass()
@@ -64,10 +64,10 @@ class BreakdownSceneOperations(HookBaseClass):
 
         refs = []
 
-        for r in vrReferenceService.getSceneReferences():
+        for r in vrReferenceService.getSceneReferences():  # noqa F821
 
             # we only want to keep the top references
-            has_parent = vrReferenceService.getParentReferences(r)
+            has_parent = vrReferenceService.getParentReferences(r)  # noqa F821
             if has_parent:
                 continue
 
@@ -122,7 +122,7 @@ class BreakdownSceneOperations(HookBaseClass):
             ref_node.setName(new_node_name)
         elif node_type == "smart_reference":
             ref_node.setSmartPath(path)
-            vrReferenceService.reimportSmartReferences([ref_node])
+            vrReferenceService.reimportSmartReferences([ref_node])  # noqa F821
 
     def register_scene_change_callback(self, scene_change_callback):
         """
@@ -145,13 +145,13 @@ class BreakdownSceneOperations(HookBaseClass):
         # based on how the references have cahnged.
         # NOTE ideally the VRED API would have signals for specific reference change events,
         # until then, any reference change will trigger a full reload of the app.
-        vrReferenceService.referencesChanged.connect(self._on_references_changed_cb)
+        vrReferenceService.referencesChanged.connect(self._on_references_changed_cb)  # noqa F821
 
     def unregister_scene_change_callback(self):
         """Unregister the scene change callbacks by disconnecting any signals."""
 
         if self._on_references_changed_cb:
-            vrReferenceService.referencesChanged.disconnect(
+            vrReferenceService.referencesChanged.disconnect(  # noqa F821
                 self._on_references_changed_cb
             )
             self._on_references_changed_cb = None
@@ -164,7 +164,7 @@ def get_reference_by_id(ref_id):
     :param ref_name: Name of the reference we want to get the associated node from
     :returns: The reference node associated to the reference name
     """
-    ref_list = vrReferenceService.getSceneReferences()
+    ref_list = vrReferenceService.getSceneReferences()  # noqa F821
     for r in ref_list:
         if r.getObjectId() == ref_id:
             return r

--- a/info.yml
+++ b/info.yml
@@ -23,7 +23,7 @@ configuration:
     hook_get_published_files:
         type: hook
         default_value: "{self}/get_published_files.py"
-        description: Specificy a hook that, if desired, defines how Pubilshed File entites are retrieved
+        description: Specificy a hook that, if desired, defines how Published File entities are retrieved
                      from the ShotGrid API.
 
     hook_ui_config:

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -8,4 +8,4 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Autodesk, Inc.
 
-from . import tk_multi_breakdown2
+from . import tk_multi_breakdown2  # noqa F401

--- a/python/tk_multi_breakdown2/__init__.py
+++ b/python/tk_multi_breakdown2/__init__.py
@@ -8,12 +8,12 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Autodesk, Inc.
 
-from .api import BreakdownManager
+from .api import BreakdownManager  # noqa F401
 
 try:
     # Attempt to import the AppDialog
     from .dialog import AppDialog
-except:
+except Exception:
     # Ignore import error for AppDialog so that the app works gracefully in batch modes
     pass
 

--- a/python/tk_multi_breakdown2/actions.py
+++ b/python/tk_multi_breakdown2/actions.py
@@ -8,8 +8,6 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Autodesk, Inc.
 
-import copy
-
 import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 

--- a/python/tk_multi_breakdown2/api/__init__.py
+++ b/python/tk_multi_breakdown2/api/__init__.py
@@ -8,4 +8,4 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Autodesk, Inc.
 
-from .manager import BreakdownManager, FileItem
+from .manager import BreakdownManager, FileItem  # noqa F401

--- a/python/tk_multi_breakdown2/api/manager.py
+++ b/python/tk_multi_breakdown2/api/manager.py
@@ -62,7 +62,18 @@ class BreakdownManager(object):
     def get_published_files_from_scene_objects(
         self, scene_objects, extra_fields=None
     ):
-        self._bundle.logger.info("Validating %s" % scene_objects)
+        """
+        Query the ShotGrid API to get the Published Files for the given scene objects.
+
+        :param scene_objects: A list of dictionaries as retrieved by scan scene.
+        :type scene_objects: List[dict]
+        :param extra_fields: A list of ShotGrid fields to append to the ShotGrid query
+                             when retreiving the published files.
+        :type extra_fields: List[str]
+
+        :return: The Published Files data.
+        :rtype: dict
+        """
         # Get the published file fields to pass to the query
         fields = self.get_published_file_fields()
         if extra_fields is not None:

--- a/python/tk_multi_breakdown2/api/manager.py
+++ b/python/tk_multi_breakdown2/api/manager.py
@@ -61,14 +61,14 @@ class BreakdownManager(object):
         return self._bundle.execute_hook_method("hook_scene_operations", "scan_scene")
 
     @sgtk.LogManager.log_timing
-    def get_published_files_for_scene_objects(
-        self, scene_objects, extra_fields=None
+    def get_published_files_for_items_data(
+        self, items_data, extra_fields=None
     ):
         """
-        Query the ShotGrid API to get the Published Files for the given scene objects.
+        Query the ShotGrid API to get the Published Files for the given items data.
 
-        :param scene_objects: A list of dictionaries as retrieved by scan scene.
-        :type scene_objects: List[dict]
+        :param items_data: A list of dictionaries as retrieved by scan scene.
+        :type items_data: List[dict]
         :param extra_fields: A list of ShotGrid fields to append to the ShotGrid query
                              when retreiving the published files.
         :type extra_fields: List[str]
@@ -83,8 +83,8 @@ class BreakdownManager(object):
 
         return self._bundle.execute_hook_method(
             "hook_get_published_files",
-            "get_published_files_for_scene_objects",
-            scene_objects=scene_objects,
+            "get_published_files_for_items_data",
+            items_data=items_data,
             fields=fields,
         )
 

--- a/python/tk_multi_breakdown2/decorators.py
+++ b/python/tk_multi_breakdown2/decorators.py
@@ -10,7 +10,6 @@
 
 from functools import wraps
 
-import sgtk
 from sgtk.platform.qt import QtGui, QtCore
 
 

--- a/python/tk_multi_breakdown2/dialog.py
+++ b/python/tk_multi_breakdown2/dialog.py
@@ -10,16 +10,15 @@
 
 import sgtk
 from sgtk.platform.qt import QtGui, QtCore
-from tank.errors import TankHookMethodDoesNotExistError
 from tank_vendor import six
 
 from .ui.dialog import Ui_Dialog
-from .ui import resources_rc  # Required for accessing icons
+from .ui import resources_rc  # noqa F401 Required for accessing icons
 
 from .file_item_model import FileTreeItemModel as FileModel
 from .file_history_model import FileHistoryModel
 from .actions import ActionManager
-from .framework_qtwidgets import (
+from .framework_qtwidgets import (  # noqa F401
     FilterItem,
     FilterMenu,
     FilterMenuButton,  # Keep this import even if the linter says its unused

--- a/python/tk_multi_breakdown2/file_history_model.py
+++ b/python/tk_multi_breakdown2/file_history_model.py
@@ -11,7 +11,7 @@
 import sgtk
 from sgtk.platform.qt import QtCore, QtGui
 
-from .ui import resources_rc  # Required for accessing icons
+from .ui import resources_rc  # noqa F401 Required for accessing icons
 from .utils import get_ui_published_file_fields
 from . import constants
 

--- a/python/tk_multi_breakdown2/file_item_model.py
+++ b/python/tk_multi_breakdown2/file_item_model.py
@@ -8,15 +8,13 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Autodesk, Inc.
 
-import copy
-
 import sgtk
 from sgtk import TankError
 from sgtk.platform.qt import QtGui, QtCore
 
 from tank_vendor import six
 
-from .ui import resources_rc  # Required for accessing icons
+from .ui import resources_rc  # noqa F401 Required for accessing icons
 from .utils import get_ui_published_file_fields
 from .decorators import wait_cursor
 
@@ -1414,7 +1412,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
             group_by_id = "{type}.{id}".format(
                 type=data.get("type", "NoType"), id=data["id"]
             )
-        except:
+        except Exception:
             # Fall back to just using the data itself as the id
             group_by_id = str(data)
 

--- a/python/tk_multi_breakdown2/file_item_model.py
+++ b/python/tk_multi_breakdown2/file_item_model.py
@@ -776,7 +776,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
             # and instead need to query ShotGrid.
             self.__pending_published_file_data_request = (
                 self._bg_task_manager.add_task(
-                    self._manager.get_published_files_for_scene_objects,
+                    self._manager.get_published_files_for_items_data,
                     task_args=[self.__scene_objects],
                     task_kwargs={"extra_fields": self._published_file_fields},
                 )
@@ -856,7 +856,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
             return
 
         # Query for the published file for the new file item and create the FileItem object.
-        published_file_items = self._manager.get_published_files_for_scene_objects(
+        published_file_items = self._manager.get_published_files_for_items_data(
             [file_item_data],
             extra_fields=self._published_file_fields,
         )

--- a/python/tk_multi_breakdown2/file_item_model.py
+++ b/python/tk_multi_breakdown2/file_item_model.py
@@ -776,7 +776,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
             # and instead need to query ShotGrid.
             self.__pending_published_file_data_request = (
                 self._bg_task_manager.add_task(
-                    self._manager.get_published_files_from_scene_objects,
+                    self._manager.get_published_files_for_scene_objects,
                     task_args=[self.__scene_objects],
                     task_kwargs={"extra_fields": self._published_file_fields},
                 )
@@ -856,13 +856,13 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
             return
 
         # Query for the published file for the new file item and create the FileItem object.
-        published_files = self._manager.get_published_files_from_scene_objects(
+        published_file_items = self._manager.get_published_files_for_scene_objects(
             [file_item_data],
             extra_fields=self._published_file_fields,
         )
 
         # Get the FileItem object from the published file data
-        file_items = self._manager.get_file_items([file_item_data], published_files)
+        file_items = self._manager.get_file_items(published_file_items)
         if not file_items:
             return False
 
@@ -1586,7 +1586,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
 
             # Get the list of FileItem objects representing the objects in the scene
             self.__file_items = self._manager.get_file_items(
-                self.__scene_objects, result
+                result
             )
 
             # Make an async request to get all published file data necessary to determine the

--- a/python/tk_multi_breakdown2/file_proxy_model.py
+++ b/python/tk_multi_breakdown2/file_proxy_model.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Autodesk, Inc.
 
 import sgtk
-from sgtk.platform.qt import QtGui, QtCore
 
 from .framework_qtwidgets import FilterItemTreeProxyModel
 

--- a/tests/test_api_manager.py
+++ b/tests/test_api_manager.py
@@ -25,7 +25,6 @@ base_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "python
 app_dir = os.path.abspath(os.path.join(base_dir, "tk_multi_breakdown2"))
 api_dir = os.path.abspath(os.path.join(app_dir, "api"))
 sys.path.extend([base_dir, app_dir, api_dir])
-from tk_multi_breakdown2 import constants
 from tk_multi_breakdown2.api import BreakdownManager
 from tk_multi_breakdown2.api.item import FileItem
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -8,7 +8,6 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Autodesk, Inc.
 
-import datetime
 import os
 import pytest
 
@@ -140,7 +139,7 @@ class TestApplication(AppTestBase):
                         )
                     )
 
-                except Exception as error:
+                except Exception:
                     # Hook executed but had an exception. This is OK since this is just a test of existence.
                     pass
 


### PR DESCRIPTION
Refactored how published files are matched to "nodes" to allow custom implementation with hooks:
- Ensured that anything with the background manager was dealt by the app only.
- Added a `get_published_files_for_items_data` hook method to allow to doing the initial match from a hook.
- Moved the  `get_published_files_from_file_paths` logic into the new `get_published_files_for_items_data` hook method.
- Changed things so building items is based on the presence of `sg_data` in the items data, so all the logic to match published files is consistently in a single place: the hook.


Added Flake8 action and fixed problems I could safely fixed.
