### PR TITLE
For #11529: history management improvements

### DIFF
--- a/hooks/get_published_files.py
+++ b/hooks/get_published_files.py
@@ -115,7 +115,6 @@ class GetPublishedFiles(HookBaseClass):
                 fields=fields,
                 order=order,
             )
-            self.logger.debug("Retrieved %d Published Files" % len(result))
             return result
 
         # No data retriever, execute synchronously and return the published file data result.
@@ -172,5 +171,5 @@ class GetPublishedFiles(HookBaseClass):
                 fields=fields,
                 order=order,
             )
-        self.logger.debug("Found latest Published File %s" % result)
+            self.logger.debug("Found latest Published File %s" % result)
         return result

--- a/info.yml
+++ b/info.yml
@@ -41,6 +41,18 @@ configuration:
         default_value: 5
         description: Number of versions to display in the file history information window.
 
+    published_file_matching_fields:
+        type: list
+        description: The Published File fields to use when looking for the publish history. They are
+                     used to match the current Published File data against other Published Files. By default,
+                     the app will look for Published Files with the same project, task, entity, name and
+                     published file type.
+        values:
+            type: str
+        allows_empty: False
+        default_value:
+          [ "project", "task", "entity", "name", "published_file_type" ]
+
     published_file_fields:
         type: list
         values: {type: str}

--- a/info.yml
+++ b/info.yml
@@ -44,13 +44,13 @@ configuration:
     publish_history_group_by_fields:
         type: list
         description: The Published File fields to use when looking for the publish history. They are
-                     used to match the current Published File data against other Published Files. By default,
-                     the app will look for Published Files with the same project, task, entity, name and
-                     published file type.
+                     used to match the current Published File data against other Published Files.
         values:
             type: str
         allows_empty: False
         default_value:
+          # By default, the app will look for Published Files with the same project, task, entity, name and
+          # published file type.
           [ "project", "task", "entity", "name", "published_file_type" ]
 
     published_file_fields:

--- a/info.yml
+++ b/info.yml
@@ -41,7 +41,7 @@ configuration:
         default_value: 5
         description: Number of versions to display in the file history information window.
 
-    published_file_matching_fields:
+    publish_history_group_by_fields:
         type: list
         description: The Published File fields to use when looking for the publish history. They are
                      used to match the current Published File data against other Published Files. By default,

--- a/python/tk_multi_breakdown2/file_history_model.py
+++ b/python/tk_multi_breakdown2/file_history_model.py
@@ -189,13 +189,13 @@ class FileHistoryModel(ShotgunModel, ViewItemRolesMixin):
             "published_file_fields", []
         )
         fields += get_ui_published_file_fields(app)
-        filters = [
-            ["project", "is", sg_data["project"]],
-            ["name", "is", sg_data["name"]],
-            ["task", "is", sg_data["task"]],
-            ["entity", "is", sg_data["entity"]],
-            ["published_file_type", "is", sg_data["published_file_type"]],
-        ]
+        # When we filter out which other publishes are associated with this one,
+        # to effectively get the "version history", we look for items
+        # based on the publish_file_matching_fields setting.
+        pub_matching_fields = app.get_setting("published_file_matching_fields", [])
+        filters = []
+        for field in pub_matching_fields:
+            filters.append([field, "is", sg_data[field]])
 
         ShotgunModel._load_data(
             self,

--- a/python/tk_multi_breakdown2/file_history_model.py
+++ b/python/tk_multi_breakdown2/file_history_model.py
@@ -191,7 +191,7 @@ class FileHistoryModel(ShotgunModel, ViewItemRolesMixin):
         fields += get_ui_published_file_fields(app)
         # When we filter out which other publishes are associated with this one,
         # to effectively get the "version history", we look for items
-        # based on the publish_file_matching_fields setting.
+        # based on the publish_history_group_by_fields setting.
         group_by_fields = app.get_setting("publish_history_group_by_fields", [])
         filters = []
         for field in group_by_fields:

--- a/python/tk_multi_breakdown2/file_history_model.py
+++ b/python/tk_multi_breakdown2/file_history_model.py
@@ -192,9 +192,9 @@ class FileHistoryModel(ShotgunModel, ViewItemRolesMixin):
         # When we filter out which other publishes are associated with this one,
         # to effectively get the "version history", we look for items
         # based on the publish_file_matching_fields setting.
-        pub_matching_fields = app.get_setting("published_file_matching_fields", [])
+        group_by_fields = app.get_setting("publish_history_group_by_fields", [])
         filters = []
-        for field in pub_matching_fields:
+        for field in group_by_fields:
             filters.append([field, "is", sg_data[field]])
 
         ShotgunModel._load_data(

--- a/python/tk_multi_breakdown2/file_item_model.py
+++ b/python/tk_multi_breakdown2/file_item_model.py
@@ -1270,14 +1270,14 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
 
     def _get_published_files_mapping(self, published_file_data):
         """
-        Return a mapping of published files by their fields specified in app settings.
+        Return a mapping of Published Files by their fields specified in app settings.
 
-        For example, if published_file_matching_fields is set to ["project", "entity", "task", "name"],
+        For example, if publish_history_group_by_fields is set to ["project", "entity", "task", "name"],
         then the returned dictionary will be a nested dictionary mapping published files by their
         project, entity, task, and name.
 
         For each level, if the value is a dictionary, then the dictionary will be mapped by the
-        dictionary's "id" value, else the value will be used as the key.
+        dictionary's "type" and "id" values, else the value will be used as the key.
 
         :param published_file_data: The list of published file data to map.
         :type published_file_data: List[dict]
@@ -1285,21 +1285,21 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         :return: The dictionary mapping for published files.
         :rtype: dict
         """
-        pub_matching_fields = self._app.get_setting("published_file_matching_fields")
+        group_by_fields = self._app.get_setting("publish_history_group_by_fields")
         published_files_mapping = {}
 
         for pf_data in published_file_data:
             current_level = published_files_mapping
 
             # Iterate over fields and navigate or create nested dictionary structure.
-            for index, field in enumerate(pub_matching_fields):
+            for index, field in enumerate(group_by_fields):
                 field_value = pf_data.get(field)
                 if isinstance(field_value, dict):
-                    field_value = field_value.get("id")
+                    field_value = (field_value.get("type"), field_value.get("id"))
 
                 # If it's last field in the loop, ensure the current_level for
                 # that key is a list and append to it.
-                if index == len(pub_matching_fields) - 1:
+                if index == len(group_by_fields) - 1:
                     current_level.setdefault(field_value, []).append(pf_data)
                 else:
                     current_level.setdefault(field_value, {})
@@ -1324,14 +1324,14 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         :rtype: dict
         """
 
-        pub_matching_fields = self._app.get_setting("published_file_matching_fields")
+        group_by_fields = self._app.get_setting("publish_history_group_by_fields")
         current_level = published_files_mapping
 
         # Iterate over fields and navigate the nested dictionary structure.
-        for field in pub_matching_fields:
+        for field in group_by_fields:
             field_value = file_item.sg_data.get(field)
             if isinstance(field_value, dict):
-                field_value = field_value.get("id")
+                field_value = (field_value.get("type"), field_value.get("id"))
             # Navigate deeper into the dictionary.
             if field_value in current_level:
                 current_level = current_level[field_value]


### PR DESCRIPTION
- Similar to what's done in https://github.com/GPLgithub/tk-multi-loader2/pull/2, add a `published_file_matching_fields` setting
- Here it also controls the published_files_mapping we do in the `file_item_model`. This is to ensure that the latest Published File is properly retrieved.
- IMHO, the logic of the get_published_files standard hook should also be based on the setting, but for now I did that in `tk-config-gplstudio` (PR to follow)