### PR TITLE
For #11529: add use_version_thumbnail_as_fallback setting

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -88,6 +88,13 @@ configuration:
                      timeout. The default interval length is 30 seconds. Set a negative valeu to not
                      perform the background file item status checks.
 
+    use_version_thumbnail_as_fallback:
+        type: bool
+        default_value: True
+        description: If set to True, when a published file lacks a thumbnail, the app will attempt to use
+                     the thumbnail from the linked Version, if available.
+                     Set to False to disable this fallback behavior.
+
 
 # The ShotGrid fields that this app needs in order to operate correctly
 requires_shotgun_fields:

--- a/python/tk_multi_breakdown2/file_item_model.py
+++ b/python/tk_multi_breakdown2/file_item_model.py
@@ -15,7 +15,7 @@ from sgtk.platform.qt import QtGui, QtCore
 from tank_vendor import six
 
 from .ui import resources_rc  # noqa F401 Required for accessing icons
-from .utils import get_ui_published_file_fields
+from .utils import get_ui_published_file_fields, get_item_image_field
 from .decorators import wait_cursor
 
 shotgun_data = sgtk.platform.import_framework(
@@ -1355,15 +1355,14 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
 
         :return: None
         """
-
-        if not file_item.sg_data.get("image"):
+        image_field = get_item_image_field(file_item)
+        if not image_field:
             return
-
         request_id = self._sg_data_retriever.request_thumbnail(
-            file_item.sg_data["image"],
+            file_item.sg_data[image_field],
             file_item.sg_data["type"],
             file_item.sg_data["id"],
-            "image",
+            image_field,
         )
 
         # Store the model item with the request id, so that the model item can be retrieved

--- a/python/tk_multi_breakdown2/file_item_model.py
+++ b/python/tk_multi_breakdown2/file_item_model.py
@@ -15,7 +15,7 @@ from sgtk.platform.qt import QtGui, QtCore
 from tank_vendor import six
 
 from .ui import resources_rc  # noqa F401 Required for accessing icons
-from .utils import get_ui_published_file_fields, get_item_image_field
+from .utils import get_ui_published_file_fields, get_thumbnail_field_for_item
 from .decorators import wait_cursor
 
 shotgun_data = sgtk.platform.import_framework(
@@ -145,6 +145,10 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         # Flag indicating if the model will poll for published file updates async.
         self.__polling = polling
 
+        # Get the app setting to use the Version thumbnail as fallback.
+        self._use_version_thumbnail_as_fallback = self._app.get_setting(
+            "use_version_thumbnail_as_fallback"
+        )
         # Get the app setting for the timeout interval length for polling file item statuses.
         self._timeout_interval = self._app.get_setting("file_status_check_interval")
         # Create a timer that checks the latest published file every X seconds
@@ -1355,7 +1359,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
 
         :return: None
         """
-        image_field = get_item_image_field(file_item)
+        image_field = get_thumbnail_field_for_item(file_item, self._use_version_thumbnail_as_fallback)
         if not image_field:
             return
         request_id = self._sg_data_retriever.request_thumbnail(

--- a/python/tk_multi_breakdown2/utils.py
+++ b/python/tk_multi_breakdown2/utils.py
@@ -10,8 +10,6 @@
 
 from .framework_qtwidgets import utils
 
-import sgtk
-
 
 def get_ui_published_file_fields(app):
     """

--- a/python/tk_multi_breakdown2/utils.py
+++ b/python/tk_multi_breakdown2/utils.py
@@ -56,8 +56,7 @@ def get_ui_published_file_fields(app):
     if file_history_config["thumbnail"]:
         if "image" not in fields:
             fields.append("image")
-        # We need the linked Version's image if setting
-        # use_version_thumbnail_as_fallback is enabled.
+        # Add the linked Version's image field to be able to fallback on it if needed.
         if "version.Version.image" not in fields:
             fields.append("version.Version.image")
 

--- a/python/tk_multi_breakdown2/utils.py
+++ b/python/tk_multi_breakdown2/utils.py
@@ -74,7 +74,7 @@ def get_item_image_field(item):
 
     It returns "image" if the item has an image field and there's an
     actual image to use. If there's no image field or no image to use,
-    it tries to use the version.Version.image field in the same way,
+    it tries to use the `version.Version.image` field in the same way,
     if setting use_version_thumbnail_as_fallback is enabled.
 
     If there's no image field or no image to use, it returns None.

--- a/python/tk_multi_breakdown2/utils.py
+++ b/python/tk_multi_breakdown2/utils.py
@@ -12,6 +12,7 @@ from .framework_qtwidgets import utils
 
 import sgtk
 
+
 def get_ui_published_file_fields(app):
     """
     Returns a list of ShotGrid fields we want to retrieve when querying ShotGrid. We're going through each widget

--- a/python/tk_multi_breakdown2/utils.py
+++ b/python/tk_multi_breakdown2/utils.py
@@ -32,8 +32,7 @@ def get_ui_published_file_fields(app):
     fields += utils.resolve_sg_fields(file_item_config.get("body"))
     if file_item_config["thumbnail"]:
         fields.append("image")
-        # We need the linked Version's image if setting
-        # use_version_thumbnail_as_fallback is enabled.
+        # Add the linked Version's image field to be able to fall back on it if needed.
         fields.append("version.Version.image")
 
     main_file_history_config = app.execute_hook_method(
@@ -45,8 +44,7 @@ def get_ui_published_file_fields(app):
     if main_file_history_config["thumbnail"]:
         if "image" not in fields:
             fields.append("image")
-        # We need the linked Version's image if setting
-        # use_version_thumbnail_as_fallback is enabled.
+        # Add the linked Version's image field to be able to fall back on it if needed.
         if "version.Version.image" not in fields:
             fields.append("version.Version.image")
 
@@ -68,25 +66,25 @@ def get_ui_published_file_fields(app):
     return list(set(fields))
 
 
-def get_item_image_field(item):
+def get_thumbnail_field_for_item(item, use_version_thumbnail_as_fallback=True):
     """
     Get the field to use for the thumbnail for the given item.
 
-    It returns "image" if the item has an image field and there's an
-    actual image to use. If there's no image field or no image to use,
-    it tries to use the `version.Version.image` field in the same way,
-    if setting use_version_thumbnail_as_fallback is enabled.
+    Check if a thumbnail is available for the given item, and return
+    the field name to download it from. If not available and falling back
+    on the Version is allowed, check if one is available for it and,
+    if so, return the dotted field to use to retrieve it.
 
     If there's no image field or no image to use, it returns None.
 
     :param item: The QStandardItem to get the thumbnail field for.
+    :param use_version_thumbnail_as_fallback: Whether to use the Version's
+        thumbnail as a fallback if the item doesn't have one.
     :returns: A SG field, e.g. "image", or ``None``.
     """
     sg_data = item.sg_data
-    app = sgtk.platform.current_bundle()
     if not sg_data:
         return None
-    use_version_thumbnail_as_fallback = app.get_setting("use_version_thumbnail_as_fallback")
     # When it's an empty thumbnail, it's an AWS link with a "no_preview_t.jpg" image.
     if sg_data.get("image") and "no_preview_t.jpg" not in sg_data.get("image"):
         return "image"


### PR DESCRIPTION
If enabled, and a thumbnail cannot be found for the Published File, try to use the Version's thumbnail, if any.

The same kind of change was applied to tk-multi-loader2 (hence the utility method in utils.py)