### PR TITLE
For #12520: integrate changes from shotgunsoftware

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Python 3.7](https://img.shields.io/badge/python-3.7-blue.svg)](https://www.python.org/)
 [![Python 3.9](https://img.shields.io/badge/python-3.9-blue.svg)](https://www.python.org/)
+[![Python 3.10](https://img.shields.io/badge/python-3.10-blue.svg)](https://www.python.org/)
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 This repository is a part of the ShotGrid Pipeline Toolkit.
 
 - For more information about this engine and for release notes, *see the wiki section*.
-- For general information and documentation, click here: https://developer.shotgridsoftware.com/d587be80/?title=Integrations+User+Guide
+- For general information and documentation, click here: https://help.autodesk.com/view/SGDEV/ENU/?contextId=SA_INTEGRATIONS_USER_GUIDE
 - For information about ShotGrid in general, click here: https://help.autodesk.com/view/SGSUB/ENU
 
 ## Using this app in your Setup
@@ -16,8 +16,8 @@ This repository is a part of the ShotGrid Pipeline Toolkit.
 All the apps that are part of our standard app suite are pushed to our App Store.
 This is where you typically go if you want to install an app into a project you are
 working on. For an overview of all the Apps and Engines in the Toolkit App Store,
-click here: https://developer.shotgridsoftware.com/162eaa4b/?title=Pipeline+Integration+Components
+click here: https://help.autodesk.com/view/SGDEV/ENU/?contextId=PC_TOOLKIT_APPS
 
 ## Have a Question?
 
-Don't hesitate to contact us! You can find us at https://developer.shotgridsoftware.com
+Don't hesitate to contact us at https://www.autodesk.com/support/contact-support

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Security
+
+At Autodesk, we know that the security of your data is critical to your studio’s
+operation.
+As the industry shifts to the cloud, ShotGrid knows that security and service
+models are more important than ever.
+
+The confidentiality, integrity, and availability of your content is at the top
+of our priority list.
+Not only do we have a team of ShotGrid engineers dedicated to platform security
+and performance, we are also backed by Autodesk’s security team, also invests
+heavily in the security for broad range of industries and customers.
+We constantly reassess, develop, and improve our risk management program because
+we know that the landscape of security is ever-changing.
+
+If you believe you have found a security vulnerability in any ShotGrid-owned
+repository, please report it to us as described below.
+
+
+## Reporting Security Issues
+
+**Please do not report security vulnerabilities through public GitHub issues.**
+
+Instead, please report them by sending a message to
+[Autodesk Trust Center](https://www.autodesk.com/trust/contact-us).
+
+Please include as much information as you can provide such as locations,
+configurations, reproduction steps, exploit code, impact, etc.
+
+
+## Additional Information
+
+Please check out the [ShotGrid Security White Paper](https://help.autodesk.com/view/SGSUB/ENU/?guid=SG_Administrator_ar_general_security_ar_security_white_paper_html).

--- a/app.py
+++ b/app.py
@@ -29,14 +29,20 @@ class SceneBreakdown2(sgtk.platform.Application):
         self._current_dialog = None
         self._current_panel = None
 
-        # Register the app as a panel.
-        self._unique_panel_id = self.engine.register_panel(self.create_panel)
+        if self.get_setting("panel_mode"):
+            # App will open in as a panel window
+            app_callback = self.create_panel
+            app_type = "panel"
+            self._unique_panel_id = self.engine.register_panel(app_callback)
+        else:
+            # App will open in a dialog window
+            app_callback = self.create_dialog
+            app_type = "dialog"
 
-        # Register a menu entry on the ShotGrid menu so that users can launch the panel.
         self.engine.register_command(
             "{}...".format(self.get_setting("display_name")),
-            self.create_panel,
-            {"type": "panel", "short_name": "breakdown"},
+            app_callback,
+            {"type": app_type, "short_name": "breakdown"},
         )
 
     def show_dialog(self):

--- a/hooks/get_published_files.py
+++ b/hooks/get_published_files.py
@@ -14,7 +14,7 @@ HookBaseClass = sgtk.get_hook_baseclass()
 
 
 class GetPublishedFiles(HookBaseClass):
-    """"""
+    """Hook to specify the query to retrieve Published Files for the app."""
 
     def get_published_files_for_items(self, items, data_retriever=None):
         """
@@ -38,19 +38,54 @@ class GetPublishedFiles(HookBaseClass):
         entities = []
         names = []
         tasks = []
+        none_entity = False
+        none_task = False
         pf_types = []
         for file_item in items:
-            entities.append(file_item.sg_data["entity"])
+            # Required published file fields are name and published file type. There will be
+            # an api error if these are not set.
             names.append(file_item.sg_data["name"])
-            tasks.append(file_item.sg_data["task"])
             pf_types.append(file_item.sg_data["published_file_type"])
+
+            # Optional fields are linked entity and task.
+            entity = file_item.sg_data["entity"]
+            if entity:
+                entities.append(entity)
+            else:
+                none_entity = True
+
+            task = file_item.sg_data["task"]
+            if task:
+                tasks.append(task)
+            else:
+                none_task = True
+
+        # Build the entity filters
+        entity_filters = []
+        if entities:
+            entity_filters.append(["entity", "in", entities])
+        if none_entity:
+            entity_filters.append(["entity", "is", None])
+
+        # Build the task filters
+        task_filters = []
+        if tasks:
+            task_filters.append(["task", "in", tasks])
+        if none_task:
+            task_filters.append(["task", "is", None])
 
         # Published files will be found by their entity, name, task and published file type.
         filters = [
-            ["entity", "in", entities],
             ["name", "in", names],
-            ["task", "in", tasks],
             ["published_file_type", "in", pf_types],
+            {
+                "filter_operator": "any",
+                "filters": entity_filters,
+            },
+            {
+                "filter_operator": "any",
+                "filters": task_filters,
+            },
         ]
 
         # Get the query fields. This assumes all file items in the list have the same fields.

--- a/hooks/get_published_files.py
+++ b/hooks/get_published_files.py
@@ -58,7 +58,7 @@ class GetPublishedFiles(HookBaseClass):
                 published_items_data.append(item_data)
         return published_items_data
 
-    def get_published_files_for_items(self, items, data_retriever=None):
+    def get_published_files_for_items(self, items, data_retriever=None, filters=None):
         """
         Make an API request to get all published files for the given file items.
 
@@ -72,6 +72,7 @@ class GetPublishedFiles(HookBaseClass):
         :param items: a list of :class`FileItem` we want to get published files for.
         :param data_retriever: If provided, the api request will be async. The default value
             will execute the api request synchronously.
+        :param filters: A list of filters to use when querying SG.
 
         :returns: If the request is async, then the request task id is returned, else the
             published file data result from the api request.
@@ -93,7 +94,7 @@ class GetPublishedFiles(HookBaseClass):
                     # If there's no data for this field, we still need to make sure
                     # there's an empty list for it to build the filters.
                     sg_data_by_field[field] = []
-        filters = []
+        filters = filters or []
         for field, values in sg_data_by_field.items():
             if values:
                 filters.append([field, "in", values])

--- a/hooks/get_published_files.py
+++ b/hooks/get_published_files.py
@@ -43,7 +43,7 @@ class GetPublishedFiles(HookBaseClass):
 
         :param items_data: A list of dictionaries as returned by the scene scanner.
         :param fields: A list of fields to query from SG.
-        :param filters: A list of filters to use when querying SG.
+        :param filters: An optional list of filters to use when querying SG.
         :returns: A list of items data for which a Published File was found.
         """
         if not items_data:

--- a/hooks/get_published_files.py
+++ b/hooks/get_published_files.py
@@ -73,7 +73,7 @@ class GetPublishedFiles(HookBaseClass):
         :param items: a list of :class`FileItem` we want to get published files for.
         :param data_retriever: If provided, the api request will be async. The default value
             will execute the api request synchronously.
-        :param filters: A list of filters to use when querying SG.
+        :param filters: An optional list of filters to use when querying SG.
 
         :returns: If the request is async, then the request task id is returned, else the
             published file data result from the api request.

--- a/hooks/get_published_files.py
+++ b/hooks/get_published_files.py
@@ -9,6 +9,7 @@
 # not expressly granted therein are reserved by Autodesk, Inc.
 
 from collections import defaultdict
+import copy
 import sgtk
 
 HookBaseClass = sgtk.get_hook_baseclass()
@@ -94,7 +95,10 @@ class GetPublishedFiles(HookBaseClass):
                     # If there's no data for this field, we still need to make sure
                     # there's an empty list for it to build the filters.
                     sg_data_by_field[field] = []
-        filters = filters or []
+
+        # Let's copy the filters so we don't modify the original list.
+        filters = copy.deepcopy(filters) if filters else []
+
         for field, values in sg_data_by_field.items():
             if values:
                 filters.append([field, "in", values])

--- a/hooks/get_published_files.py
+++ b/hooks/get_published_files.py
@@ -19,7 +19,7 @@ class GetPublishedFiles(HookBaseClass):
     Hook called to retrieve the Published Files for the items in the scene.
     """
 
-    def get_published_files_for_items_data(self, items_data, fields):
+    def get_published_files_for_items_data(self, items_data, fields, filters=None):
         """
         Return the Published Files for the given items data.
 
@@ -42,13 +42,14 @@ class GetPublishedFiles(HookBaseClass):
 
         :param items_data: A list of dictionaries as returned by the scene scanner.
         :param fields: A list of fields to query from SG.
+        :param filters: A list of filters to use when querying SG.
         :returns: A list of items data for which a Published File was found.
         """
         if not items_data:
             return []
         file_paths = [o["path"] for o in items_data]
         publishes = sgtk.util.find_publish(
-            self.sgtk, file_paths, fields=fields, only_current_project=False
+            self.sgtk, file_paths, fields=fields, filters=filters, only_current_project=False
         )
         published_items_data = []
         for item_data in items_data:

--- a/info.yml
+++ b/info.yml
@@ -15,6 +15,11 @@ configuration:
         default_value: Scene Breakdown
         description: Specify a name for the app, its' menu item and the ui.
 
+    panel_mode:
+        type: bool
+        default_value: True
+        description: Specify if the app window should launch as panel or dialog.
+
     hook_scene_operations:
         type: hook
         default_value: "{self}/{engine_name}_scene_operations.py"

--- a/info.yml
+++ b/info.yml
@@ -53,6 +53,18 @@ configuration:
         description: List of Published File fields returned when querying ShotGrid for published file history.
                      These fields will also be used when scanning the scene to get the current scene elements.
 
+    published_file_filters:
+        type: list
+        description: List of filters that will be applied when querying ShotGrid for Published Files based on
+                     the items found in the scene. To show Published Files without a Task, remove the default
+                     filter to exclude Published Files that do not have a Task, and similarly for Link entity.
+        values:
+            type: shotgun_filter
+        allows_empty: True
+        default_value:
+          - [task, is_not, null]
+          - [entity, is_not, null]
+
     group_by:
         type: str
         default_value: project

--- a/python/tk_multi_breakdown2/api/manager.py
+++ b/python/tk_multi_breakdown2/api/manager.py
@@ -87,13 +87,20 @@ class BreakdownManager(object):
         if extra_fields is not None:
             fields += extra_fields
 
+        # Get the published file filters to pass to the query
+        filters = self.get_published_file_filters()
+
         # Option to run this in a background task since this can take some time to execute.
         if bg_task_manager:
             # Execute the request async and return the task id for the operation.
             return bg_task_manager.add_task(
                 sgtk.util.find_publish,
                 task_args=[self._bundle.sgtk, file_paths],
-                task_kwargs={"fields": fields, "only_current_project": False},
+                task_kwargs={
+                    "filters": filters,
+                    "fields": fields,
+                    "only_current_project": False,
+                },
             )
 
         # No background task manager provided, execute the request synchronously and return
@@ -156,6 +163,17 @@ class BreakdownManager(object):
         return constants.PUBLISHED_FILES_FIELDS + self._bundle.get_setting(
             "published_file_fields", []
         )
+
+    def get_published_file_filters(self):
+        """
+        Get additional filters to pass to the query to retrieve the published files when
+        scanning the scene.
+
+        :return: The published file filters.
+        :rtype: List[List[dict]]
+        """
+
+        return self._bundle.get_setting("published_file_filters", [])
 
     def get_latest_published_file(self, item, data_retriever=None):
         """

--- a/python/tk_multi_breakdown2/api/manager.py
+++ b/python/tk_multi_breakdown2/api/manager.py
@@ -211,6 +211,7 @@ class BreakdownManager(object):
             "get_published_files_for_items",
             items=items,
             data_retriever=data_retriever,
+            filters=self.get_published_file_filters()
         )
 
     def get_published_file_history(self, item, extra_fields=None):

--- a/python/tk_multi_breakdown2/api/manager.py
+++ b/python/tk_multi_breakdown2/api/manager.py
@@ -76,8 +76,9 @@ class BreakdownManager(object):
         :return: The Published Files data.
         :rtype: dict
         """
-        # Get the published file fields to pass to the query
+        # Get the published file fields and filters to pass to the query
         fields = self.get_published_file_fields()
+        filters = self.get_published_file_filters()
         if extra_fields is not None:
             fields += extra_fields
 
@@ -86,6 +87,7 @@ class BreakdownManager(object):
             "get_published_files_for_items_data",
             items_data=items_data,
             fields=fields,
+            filters=filters,
         )
 
     def get_file_items(self, scene_objects):

--- a/python/tk_multi_breakdown2/dialog.py
+++ b/python/tk_multi_breakdown2/dialog.py
@@ -897,6 +897,8 @@ class AppDialog(QtGui.QWidget):
 
             model_index = selected_items[0]
             file_item = model_index.data(FileModel.FILE_ITEM_ROLE)
+            if not file_item:
+                return
             thumbnail = model_index.data(QtCore.Qt.DecorationRole)
 
             # display file item details

--- a/python/tk_multi_breakdown2/dialog.py
+++ b/python/tk_multi_breakdown2/dialog.py
@@ -438,8 +438,13 @@ class AppDialog(QtGui.QWidget):
         self._listen_for_events(self._auto_refresh)
 
         # -----------------------------------------------------
-        # Log metric for app usage
+        # Prepare for app start up
 
+        # Flag indicating if the model data should reload on the app show event. Initialize the
+        # flag to True to load the model the first time the app is shown.
+        self.__update_on_show = True
+
+        # Log metric for app usage
         self._bundle._log_metric_viewed_app()
 
     ######################################################################################################
@@ -461,23 +466,17 @@ class AppDialog(QtGui.QWidget):
         :type event: QtGui.QShowEvent
         """
 
-        # Refresh the view on showing the app
-        self._reload_file_model()
+        # Do not refresh when show event is caused by the window system, only internal events
+        if event.spontaneous():
+            return
+
+        if self.__update_on_show:
+            # There were changes while the app was hiding, reset the flag and refresh the
+            # model data
+            self.__update_on_show = False
+            self._reload_file_model()
 
         super(AppDialog, self).showEvent(event)
-
-    def hideEvent(self, event):
-        """
-        Override the base method.
-
-        :param event: The hide event object.
-        :type event: QtGui.QHideEvent
-        """
-
-        if self._file_model:
-            self._file_model.clear()
-
-        super(AppDialog, self).hideEvent(event)
 
     def closeEvent(self, event):
         """
@@ -990,6 +989,12 @@ class AppDialog(QtGui.QWidget):
         :param data: The data that has changed.
         :type data: str | dict
         """
+
+        if not self.isVisible():
+            # Do not perform any actions while the app is hiding. Record that there was a
+            # change and reload the model next time on show.
+            self.__update_on_show = True
+            return
 
         invalidate_filtering = False
         is_reload = event_type == "reload"

--- a/python/tk_multi_breakdown2/file_history_model.py
+++ b/python/tk_multi_breakdown2/file_history_model.py
@@ -65,8 +65,10 @@ class FileHistoryModel(ShotgunModel, ViewItemRolesMixin):
 
         self._app = sgtk.platform.current_bundle()
 
-        # Store parent file item of the items in this model.
-        self._parent_file = None
+        # Store parent file item data
+        self.__parent_sg_data = None
+        self.__parent_locked = None
+        self.__parent_highest_version_number = None
 
         # Add additional roles defined by the ViewItemRolesMixin class.
         self.NEXT_AVAILABLE_ROLE = self.initialize_roles(self.NEXT_AVAILABLE_ROLE)
@@ -88,46 +90,14 @@ class FileHistoryModel(ShotgunModel, ViewItemRolesMixin):
         }
 
     @property
-    def parent_file(self):
-        """
-        Get or set the parent file of the items in this model. Setting the parent file will update
-        the each item's data in the model based on the changes to the parent. If the parent file
-        has changed to a new parent, the load_data method should be called instead of updating
-        this property.
-        """
-        return self._parent_file
-
-    @parent_file.setter
-    def parent_file(self, parent):
-        self._parent_file = parent
-
-        # Update all items in the model. Note that this does not reload the data, it just updates
-        # the history items based on the parent changes. If the parent has changed to a different
-        # objects, then load_data should be called instead.
-        for row in range(self.rowCount()):
-            item = self.item(row)
-            sg_data = item.get_sg_data()
-            self._populate_item(item, sg_data)
-
-    @property
     def parent_entity(self):
-        """
-        Get the ShotGrid entity data dictionary that the parent file item represents.
-        """
-        if not self.parent_file:
-            return None
-
-        return self.parent_file.sg_data
+        """Get the ShotGrid entity data dictionary that the parent file item represents."""
+        return self.__parent_sg_data
 
     @property
     def parent_locked(self):
-        """
-        Get whether or not the parent file is locked to its current version.
-        """
-        if not self.parent_file:
-            return None
-
-        return self.parent_file.locked
+        """Get whether or not the parent file is locked to its current version."""
+        return self.__parent_locked
 
     @property
     def highest_version_number(self):
@@ -135,10 +105,7 @@ class FileHistoryModel(ShotgunModel, ViewItemRolesMixin):
         Get the highest version number that an item in this model can have. The highest version number
         is retrieved from the parent file.
         """
-        if not self.parent_file:
-            return None
-
-        return self.parent_file.highest_version_number or -1
+        return self.__parent_highest_version_number or -1
 
     def data(self, index, role=QtCore.Qt.DisplayRole):
         """
@@ -178,23 +145,24 @@ class FileHistoryModel(ShotgunModel, ViewItemRolesMixin):
         :type sg_data: FileItem
         """
 
-        # Store the parent file item. Do not use the property setter, since that will cause the
-        # _populate_item to be unecessarily called twice per item.
-        self._parent_file = parent_file
-        sg_data = self._parent_file.sg_data
+        self.__parent_sg_data = parent_file.sg_data if parent_file else {}
+        self.__parent_locked = parent_file.locked if parent_file else None
+        self.__parent_highest_version_number = (
+            parent_file.highest_version_number
+            if parent_file and parent_file.highest_version_number
+            else -1
+        )
 
-        app = sgtk.platform.current_bundle()
-
-        fields = constants.PUBLISHED_FILES_FIELDS + app.get_setting(
+        fields = constants.PUBLISHED_FILES_FIELDS + self._app.get_setting(
             "published_file_fields", []
         )
-        fields += get_ui_published_file_fields(app)
+        fields += get_ui_published_file_fields(self._app)
         filters = [
-            ["project", "is", sg_data["project"]],
-            ["name", "is", sg_data["name"]],
-            ["task", "is", sg_data["task"]],
-            ["entity", "is", sg_data["entity"]],
-            ["published_file_type", "is", sg_data["published_file_type"]],
+            ["project", "is", self.parent_entity["project"]],
+            ["name", "is", self.parent_entity["name"]],
+            ["task", "is", self.parent_entity["task"]],
+            ["entity", "is", self.parent_entity["entity"]],
+            ["published_file_type", "is", self.parent_entity["published_file_type"]],
         ]
 
         ShotgunModel._load_data(

--- a/python/tk_multi_breakdown2/file_item_model.py
+++ b/python/tk_multi_breakdown2/file_item_model.py
@@ -124,14 +124,9 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         super(FileTreeItemModel, self).__init__(parent)
 
         # The model data
-        # Create the (invisible) tree root item. All top level layer item will be added as
+        # Create the (invisible) tree root item. All top level file item will be added as
         # children to this root item.
         self.__root_item = FileTreeModelItem(None)
-
-        # Keep a list of all the layer item objects. This is a workaround to not being able
-        # to use the QModelIndex.internalPointer data storage (in Python, the internal pointer
-        # object is garbage collected and crashes when trying to acces it)
-        self.__data = {id(None): self.__root_item}
 
         # ------------------------------------------------------------------------------------
 
@@ -263,76 +258,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         self.__dynamic_loading = value
 
     # ----------------------------------------------------------------------
-    # Helper functions to work around not being able to use QModelIndex.internalPointer
-
-    def __get_ptr_id(self, file_item):
-        """
-        Return a unique id the layer item object to pass to the createIndex method.
-
-        :param layer_item: The layer item to get the id for.
-        :type layer_item: LayerTreeItem
-
-        :return: The id for the layer item.
-        :rtype: int
-        """
-
-        if file_item:
-            ptr_id = file_item
-        else:
-            ptr_id = None
-
-        return id(ptr_id)
-
-    def __get_internal_data(self, index):
-        """
-        Return the layer item object for the index.
-
-        :param index: The index to get the internal data for.
-        :type index: QtCore.QModelIndex
-
-        :return: The layer item object at the specifed index.
-        :rtype: LayerTreeItem
-        """
-
-        ptr_id = index.internalId()
-        return self.__data.get(ptr_id)
-
-    def __set_internal_data(self, file_item):
-        """
-        Store the layer item object data in the model's internal data storage.
-
-        :param layer_item: The layer item obejct to store.
-        :type layer_item: LayerTreeItem
-        """
-
-        ptr_id = self.__get_ptr_id(file_item)
-        self.__data[ptr_id] = file_item
-
-    def __remove_internal_data(self, index):
-        """
-        Store the layer item object data in the model's internal data storage.
-
-        :param layer_item: The layer item obejct to store.
-        :type layer_item: LayerTreeItem
-        """
-
-        ptr_id = index.internalId()
-        del self.__data[ptr_id]
-
-    # ----------------------------------------------------------------------
     # Implement required base QAbstractItemModel methods
-
-    def createIndex(self, row, column, ptr):
-        """
-        Override the base QAbstractItemModel method.
-
-        Intercept the createIndex method to get the id for the ptr and pass this id
-        instead of the ptr itself. This is a workaround to not being able to use the
-        QModelIndex.internalPointer object storage.
-        """
-
-        ptr_id = self.__get_ptr_id(ptr)
-        return super(FileTreeItemModel, self).createIndex(row, column, ptr_id)
 
     def index(self, row, column=0, parent=QtCore.QModelIndex()):
         """Return the index of hte item in the model specified by the given row, column and parent index."""
@@ -343,13 +269,13 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         if not parent.isValid():
             parent_item = self.__root_item
         else:
-            parent_item = self.__get_internal_data(parent)
+            parent_item = parent.internalPointer()
 
         child_item = parent_item.child(row)
         if child_item:
             return self.createIndex(row, column, child_item)
 
-        return self.createIndex(row, column, None)
+        return self.createIndex(row, column, self.__root_item)
 
     def parent(self, index):
         """Return the parent of the model item with the given index."""
@@ -357,7 +283,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         if not index.isValid():
             return QtCore.QModelIndex()
 
-        child_item = self.__get_internal_data(index)
+        child_item = index.internalPointer()
         if not child_item:
             return QtCore.QModelIndex()
 
@@ -379,8 +305,11 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         if not parent.isValid():
             parent_item = self.__root_item
         else:
-            parent_item = self.__get_internal_data(parent)
+            parent_item = parent.internalPointer()
 
+        assert parent_item
+        if not parent_item:
+            return -1
         return parent_item.child_count()
 
     def data(self, index, role=QtCore.Qt.DisplayRole):
@@ -389,7 +318,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         if not index.isValid():
             return None
 
-        model_item = self.__get_internal_data(index)
+        model_item = index.internalPointer()
         if not model_item:
             return None
 
@@ -568,7 +497,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         if not index.isValid():
             return False
 
-        model_item = self.__get_internal_data(index)
+        model_item = index.internalPointer()
         if not model_item:
             return False
 
@@ -629,7 +558,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         if not parent.isValid():
             parent_item = self.__root_item
         else:
-            parent_item = self.__get_internal_data(parent)
+            parent_item = parent.internalPointer()
 
         # Insert the rows now
         if row == parent_item.child_count():
@@ -638,13 +567,11 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
                 item = FileTreeModelItem()
                 parent_item.append_child(item)
                 item.parent_item = parent_item
-                self.__set_internal_data(item)
         else:
             for i in range(count):
                 item = FileTreeModelItem()
                 parent_item.child_items.insert(row + i, item)
                 item.parent_item = parent_item
-                self.__set_internal_data(item)
 
         self.endInsertRows()
 
@@ -660,11 +587,10 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
             if not parent.isValid():
                 parent_item = self.__root_item
             else:
-                parent_item = self.__get_internal_data(parent)
+                parent_item = parent.internalPointer()
 
             # Update the model internal data
             del parent_item.child_items[row : row + count]
-            self.__remove_internal_data(index)
 
             success = True
         else:
@@ -716,7 +642,6 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         """
 
         self.__root_item.reset()
-        self.__data = {id(None): self.__root_item}
 
         self.__scene_objects = []
         self.__file_items = []
@@ -887,7 +812,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
             self.setData(group_index, group_by_id, self.GROUP_ID_ROLE)
             self.setData(group_index, group_by_display, self.GROUP_DISPLAY_ROLE)
 
-            group_item = self.__get_internal_data(group_index)
+            group_item = group_index.internalPointer()
             self._group_items[group_by_id] = group_item
         else:
             # Get the existing group item to add the new file model item to.
@@ -902,7 +827,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
             self.setData(item_index, file_item, self.FILE_ITEM_ROLE)
 
             # Request the thumbnail data
-            file_model_item = self.__get_internal_data(item_index)
+            file_model_item = item_index.internalPointer()
             self._request_thumbnail(file_model_item, file_item)
 
             # Update the internal data with the new file item.
@@ -997,7 +922,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
 
         for group_row in range(row_count):
             group_index = self.index(group_row, 0)
-            group_item = self.__get_internal_data(group_index)
+            group_item = group_index.internalPointer()
 
             num_children = group_item.child_count()
             for child_row in range(num_children):
@@ -1007,8 +932,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
                     self.data(child_index, FileTreeItemModel.FILE_ITEM_ROLE)
                     == file_item
                 ):
-                    child_item = self.__get_internal_data(child_index)
-                    return child_item
+                    return child_index.internalPointer()
 
         return None
 
@@ -1031,7 +955,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
 
         for group_row in range(row_count):
             group_index = self.index(group_row, 0)
-            group_item = self.__get_internal_data(group_index)
+            group_item = group_index.internalPointer()
 
             num_children = group_item.child_count()
             for child_row in range(num_children):
@@ -1146,7 +1070,6 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
                     group_id=group_by_id, group_display=group_by_display
                 )
                 self._group_items[group_by_id] = group_item
-                self.__set_internal_data(group_item)
             else:
                 group_item = self._group_items[group_by_id]
 
@@ -1158,7 +1081,6 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
                 )
 
             file_model_item = FileTreeModelItem(file_item=file_item)
-            self.__set_internal_data(file_model_item)
 
             # Make async requests to get the item thumbnail data while the model data is being
             # processed.
@@ -1201,7 +1123,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
 
         for row in range(row_count):
             group_index = self.index(row, 0)
-            group_item = self.__get_internal_data(group_index)
+            group_item = group_index.internalPointer()
             child_row_count = group_item.child_count()
 
             for child_row in range(child_row_count):
@@ -1229,7 +1151,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
             if not index.isValid():
                 return False
 
-            model_item = self.__get_internal_data(index)
+            model_item = index.internalPointer()
             if model_item in [v[1] for v in self.__pending_thumbnail_requests.values()]:
                 return True
 
@@ -1631,7 +1553,7 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
 
 
 class FileModelItem:
-    """Data structure to hold information about an item in the Layer model."""
+    """Data structure to hold information about an item in the File model."""
 
     def __init__(self, file_item):
         """Initialize the file item."""
@@ -1656,6 +1578,12 @@ class FileModelItem:
             return False
 
         return self.file_item_id == other.file_item_id
+
+    def __hash__(self):
+        """Override the base method to allow FileModelItem objects to be hashable."""
+
+        # The file item is guaranteed to be unique by the file_item_id value.
+        return hash(self.file_item_id)
 
     # ----------------------------------------------------------------------
     # Properties
@@ -1739,6 +1667,13 @@ class FileTreeModelItem(FileModelItem):
         # They are both file items, compare their file ids.
         return self.file_item_id == other.file_item_id
 
+    def __hash__(self):
+        """Override the base method to allow FileModelItem objects to be hashable."""
+
+        # The file item is guaranteed to be unique by the combined values of the file_item_id
+        # and the group id.
+        return hash((self.file_item_id, self.group_id))
+
     # ----------------------------------------------------------------------
     # Properties
 
@@ -1762,12 +1697,12 @@ class FileTreeModelItem(FileModelItem):
 
     @property
     def child_items(self):
-        """Get the layer tree item's child items."""
+        """Get the file tree item's child items."""
         return self.__child_items
 
     @property
     def parent_item(self):
-        """Get or set the layer tree item's paretn item."""
+        """Get or set the file tree item's paretn item."""
         return self.__parent_item
 
     @parent_item.setter
@@ -1782,7 +1717,7 @@ class FileTreeModelItem(FileModelItem):
         Add a child item to this item.
 
         :param child_item: The child item to add.
-        :type child_item: LayerTreeItem
+        :type child_item: FileTreeModelItem
         """
 
         self.__child_items.append(child_item)
@@ -1795,7 +1730,7 @@ class FileTreeModelItem(FileModelItem):
         :type row: int
 
         :return: The child item.
-        :rtype: LayerTreeItem
+        :rtype: FileTreeModelItem
         """
         if row < 0 or row >= len(self.__child_items):
             return None
@@ -1812,7 +1747,11 @@ class FileTreeModelItem(FileModelItem):
         if self.parent_item is None:
             return 0
 
-        return self.__parent_item.child_items.index(self)
+        try:
+            return self.__parent_item.child_items.index(self)
+        except ValueError:
+            # This item is not in the list
+            return -1
 
     def reset(self):
         """Reset the tree item data."""

--- a/python/tk_multi_breakdown2/file_item_model.py
+++ b/python/tk_multi_breakdown2/file_item_model.py
@@ -1491,6 +1491,9 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         elif uid == self.__pending_latest_published_files_data_request:
             self.__pending_latest_published_files_data_request = None
 
+        if error_msg:
+            raise Exception(error_msg)
+
     def _on_background_task_completed(self, uid, group_id, result):
         """
         Callback triggered when the background manager has finished doing some task. The only
@@ -1531,6 +1534,9 @@ class FileTreeItemModel(QtCore.QAbstractItemModel, ViewItemRolesMixin):
         if uid == self.__pending_published_file_data_request:
             self.__pending_published_file_data_request = None
             self._finish_reload()
+
+        if msg:
+            raise Exception(msg)
 
     def _on_background_task_group_finished(self, group_id):
         """

--- a/resources/build_resources.sh
+++ b/resources/build_resources.sh
@@ -16,8 +16,6 @@ UI_PYTHON_PATH=../python/tk_multi_breakdown2/ui
 # The path to where the PySide binaries are installed
 PYTHON_BASE="/Applications/Shotgun.app/Contents/Resources/Python/bin"
 
-# Remove any problematic profiles from pngs.
-for f in *.png; do mogrify $f; done
 
 # Helper functions to build UI files
 function build_qt {


### PR DESCRIPTION
The biggest change that kind of clashed with what we have changed is the addition of the `published_file_filters` setting. Since we added some `get_published_files_for_items_data` in our manager/hook setup, I mimicked the changes that were done to `get_published_files_for_items` (i.e. adding a filters param to the hook method and setting it to the user setting when called)

Other than that, all the changes come from shotgunsoftware. I tested as much as I could and it does not seem to break.
We have a base `get_published_files.py` hook in our `tk-config-gplstudio` that also needs a slight update to add the `filters` param.